### PR TITLE
Removed the wrap to bypass puppet 4 errors

### DIFF
--- a/lib/puppet/util/network_device/dsl.rb
+++ b/lib/puppet/util/network_device/dsl.rb
@@ -52,7 +52,7 @@ module Puppet::Util::NetworkDevice::Dsl
   def register_new_module(mod, path_addition = "")
     @included_modules ||= []
     unless @included_modules.include?(mod)
-      Puppet::Util::Autoload.new(self, File.join(mod_path_base, path_addition), :wrap => false).load(mod)
+      Puppet::Util::Autoload.new(self, File.join(mod_path_base, path_addition)).load(mod)
       if path_addition.empty?
         mod_const_base.const_get(mod.to_s.capitalize).register(self)
         @included_modules << mod


### PR DESCRIPTION
This seems to get it so it compiles happily and puppet device runs without errors.